### PR TITLE
Code view now displays api example code

### DIFF
--- a/client/src/Pages/home/Components/Learning-Tool-Menu/Code-View/Code-View-Window/Code-View-Window.jsx
+++ b/client/src/Pages/home/Components/Learning-Tool-Menu/Code-View/Code-View-Window/Code-View-Window.jsx
@@ -2,15 +2,13 @@
 //import React, { useState, useRef, useEffect } from "react";
 //import "./Code-View-Window.css";
 
-
-const CodeViewWindow = (props) => {
-
+const CodeViewWindow = ({ selectedLanguageCode }) => {
     return (
-        <>
-            <h5 className="card-title">{props.selectedLanguage}</h5>
-            <p className="card-text">{props.selectedLanguageCode}</p>
-        </>
+        <div className="code-view-container" style={{ whiteSpace: "pre-wrap" }}>
+            {/* Render the processed code as HTML */}
+            <div dangerouslySetInnerHTML={{ __html: selectedLanguageCode }} />
+        </div>
     );
-}
+};
 
 export default CodeViewWindow;

--- a/client/src/Pages/home/Components/Learning-Tool-Menu/Code-View/Code-View.jsx
+++ b/client/src/Pages/home/Components/Learning-Tool-Menu/Code-View/Code-View.jsx
@@ -10,6 +10,13 @@ const CodeView = () => {
         "Select a language to view the example."
     );
 
+    // Adjusted processData to handle \\n and \\t from the API response
+    const processData = (code) => {
+        return code
+            .replace(/\\n/g, "<br>") // Replace \\n with <br>
+            .replace(/\\t/g, "&nbsp;&nbsp;&nbsp;&nbsp;"); // Replace \\t with four non-breaking spaces
+    };
+
     useEffect(() => {
         const fetchData = async () => {
             try {
@@ -26,7 +33,7 @@ const CodeView = () => {
                 );
                 setSelectedLanguageCode(
                     languageData
-                        ? languageData.Example
+                        ? processData(languageData.Example)
                         : `No example code found for ${selectedLanguage}`
                 );
             } catch (error) {
@@ -37,7 +44,7 @@ const CodeView = () => {
             }
         };
         fetchData();
-    }, [selectedLanguage]); // This will re-fetch when selectedLanguage changes
+    }, [selectedLanguage]);
 
     return (
         <>
@@ -50,7 +57,6 @@ const CodeView = () => {
                 </div>
                 <div className="card-body">
                     <CodeViewWindow
-                        selectedLanguage={selectedLanguage}
                         selectedLanguageCode={selectedLanguageCode}
                     />
                 </div>


### PR DESCRIPTION
-Code is formatted correctly using new lines and tabs in appropriate locations -Slight issue; for some reason, the Python example code has a newline at the very front of it